### PR TITLE
Timeouts and Update targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,5 +165,14 @@ get-logs:
 	@mkdir -p  logs/$(CLUSTER_ID)
 	@aws emr get --cluster-id $(CLUSTER_ID) --key-pair-file "${HOME}/${EC2_KEY}.pem" --src "/tmp/spark-logs/" --dest logs/$(CLUSTER_ID)
 
+update-site: viewer/site.tgz
+	@aws s3 cp viewer/site.tgz ${S3_URI}/
+	@aws emr ssh --cluster-id $(CLUSTER_ID) --key-pair-file "${HOME}/${EC2_KEY}.pem" \
+		--command "aws s3 cp ${S3_URI}/site.tgz /tmp/site.tgz && sudo tar -xzf /tmp/site.tgz -C /var/www/html"
+
+update-tile-server: ${SERVER_ASSEMBLY}
+	@aws s3 cp ${SERVER_ASSEMBLY} ${S3_URI}/
+	@aws emr ssh --cluster-id $(CLUSTER_ID) --key-pair-file "${HOME}/${EC2_KEY}.pem" \
+		--command "aws s3 cp ${S3_URI}/server-assembly-0.1.0.jar /tmp/tile-server.jar && (sudo stop tile-server; sudo start tile-server)"
 
 .PHONY: local-ingest ingest local-tile-server update-route53 get-logs

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -1,1 +1,5 @@
 tutorial.colorbreaks="0:ffffe5ff;0.1:f7fcb9ff;0.2:d9f0a3ff;0.3:addd8eff;0.4:78c679ff;0.5:41ab5dff;0.6:238443ff;0.7:006837ff;1:004529ff"
+spray.can.server {
+   request-timeout = 4 minutes
+   idle-timeout    = 10 minutes
+}


### PR DESCRIPTION
Timeouts prevent the the connection from being severed for big requests taking over 20s.
Update targets `update-site` and `update-tile-server` helps to patch running cluster with local changes.