### PR TITLE
Update To 1.2.0-RC2

### DIFF
--- a/ingest/build.sbt
+++ b/ingest/build.sbt
@@ -9,28 +9,28 @@ connectInput in run := true
 libraryDependencies ++= Seq(
   "com.azavea" %% "scala-landsat-util" % "1.0.0",
   "org.locationtech.geotrellis" %% "geotrellis-spark-etl" % Version.geotrellis,
-  "org.apache.spark"      %% "spark-core" % "2.1.0" % "provided",
+  "org.apache.spark" %% "spark-core" % "2.1.0" % "provided",
   "org.locationtech.geotrellis" %% "geotrellis-spark-testkit" % Version.geotrellis % "test",
-  "org.scalatest"         %%  "scalatest"      % "3.0.0" % "test"
+  "org.scalatest" %%  "scalatest" % "3.0.1" % "test"
 )
 
+assemblyShadeRules in assembly := {
+  val shadePackage = "com.azavea.shaded.demo"
+  Seq(
+    ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1")
+      .inLibrary(
+      "com.azavea.geotrellis" %% "geotrellis-cassandra" % Version.geotrellis,
+        "com.github.fge" % "json-schema-validator" % "2.2.6"
+    ).inAll
+  )
+}
+
+test in assembly := {}
+
 assemblyMergeStrategy in assembly := {
-  case "reference.conf" => MergeStrategy.concat
-  case "application.conf" => MergeStrategy.concat
-  case "META-INF/MANIFEST.MF" => MergeStrategy.discard
-  case "META-INF\\MANIFEST.MF" => MergeStrategy.discard
-  case "META-INF/ECLIPSEF.RSA" => MergeStrategy.discard
-  case "META-INF/ECLIPSEF.SF" => MergeStrategy.discard
+  case m if m.toLowerCase.endsWith("manifest.mf") => MergeStrategy.discard
+  case m if m.toLowerCase.matches("meta-inf.*\\.sf$") => MergeStrategy.discard
+  case "reference.conf" | "application.conf" => MergeStrategy.concat
   case _ => MergeStrategy.first
 }
 
-// assemblyShadeRules in assembly := {
-//   val shadePackage = "com.azavea.shaded.demo"
-//   Seq(
-//     ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1")
-//       .inLibrary(
-//         "org.locationtech.geotrellis" %% "geotrellis-cassandra" % Version.geotrellis,
-//         "com.github.fge" % "json-schema-validator" % "2.2.6"
-//       ).inAll
-//   )
-// }

--- a/ingest/build.sbt
+++ b/ingest/build.sbt
@@ -7,7 +7,7 @@ fork in run := true
 connectInput in run := true
 
 libraryDependencies ++= Seq(
-  "com.azavea" %% "scala-landsat-util" % "1.0.0",
+  "com.azavea" %% "scala-landsat-util" % "1.0.1-SNAPSHOT",
   "org.locationtech.geotrellis" %% "geotrellis-spark-etl" % Version.geotrellis,
   "org.apache.spark" %% "spark-core" % "2.1.0" % "provided",
   "org.locationtech.geotrellis" %% "geotrellis-spark-testkit" % Version.geotrellis % "test",

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,4 @@
 object Version {
-  val geotrellis = "1.0.0"
-  val scala = "2.11.8"
+  val geotrellis = "1.2.0-SNAPSHOT"
+  val scala = "2.11.11"
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,4 @@
 object Version {
-  val geotrellis = "1.2.0-RC1"
+  val geotrellis = "1.2.0-RC2"
   val scala = "2.11.11"
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,4 @@
 object Version {
-  val geotrellis = "1.2.0-SNAPSHOT"
+  val geotrellis = "1.2.0-RC1"
   val scala = "2.11.11"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,6 @@
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.7.1")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,5 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
-addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")
-
+addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -12,28 +12,31 @@ libraryDependencies ++= Seq(
   "org.locationtech.geotrellis" %% "geotrellis-accumulo" % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-hbase" % Version.geotrellis,
   "org.locationtech.geotrellis" %% "geotrellis-cassandra" % Version.geotrellis,
-  "org.apache.spark"      %% "spark-core" % "2.0.0" % "provided",
+  "org.apache.spark" %% "spark-core" % "2.1.0" % "provided",
   Dependencies.akkaHttp,
   "com.typesafe.akka" %% "akka-http-spray-json" % "10.0.3",
-  "ch.megard" %% "akka-http-cors" % "0.1.10",
-  "org.scalatest"       %%  "scalatest"      % "3.0.0" % "test"
+  "ch.megard" %% "akka-http-cors" % "0.1.11",
+  "org.scalatest" %%  "scalatest" % "3.0.1" % "test"
 )
-
-assemblyMergeStrategy in assembly := {
-  case "reference.conf" => MergeStrategy.concat
-  case "application.conf" => MergeStrategy.concat
-  case "META-INF/MANIFEST.MF" => MergeStrategy.discard
-  case "META-INF\\MANIFEST.MF" => MergeStrategy.discard
-  case "META-INF/ECLIPSEF.RSA" => MergeStrategy.discard
-  case "META-INF/ECLIPSEF.SF" => MergeStrategy.discard
-  case _ => MergeStrategy.first
-}
 
 Revolver.settings
 
 assemblyShadeRules in assembly := {
   val shadePackage = "com.azavea.shaded.demo"
   Seq(
-    ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1").inProject
+    ShadeRule.rename("com.google.common.**" -> s"$shadePackage.google.common.@1")
+      .inLibrary(
+      "com.azavea.geotrellis" %% "geotrellis-cassandra" % Version.geotrellis,
+        "com.github.fge" % "json-schema-validator" % "2.2.6"
+    ).inAll
   )
+}
+
+test in assembly := {}
+
+assemblyMergeStrategy in assembly := {
+  case m if m.toLowerCase.endsWith("manifest.mf") => MergeStrategy.discard
+  case m if m.toLowerCase.matches("meta-inf.*\\.sf$") => MergeStrategy.discard
+  case "reference.conf" | "application.conf" => MergeStrategy.concat
+  case _ => MergeStrategy.first
 }


### PR DESCRIPTION
This is actually not usable as-is because 1.2.0-RC1 versions of `geotrellis-spark-etl` and `geotrellis-spark-testkit` are not published.

Depends on https://github.com/geotrellis/geotrellis-landsat-emr-demo/pull/25
See also https://github.com/azavea/scala-landsat-util/pull/21